### PR TITLE
Use immutable stats objects

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.3
+julia 0.4
 StatsBase
 Distributions

--- a/src/moments.jl
+++ b/src/moments.jl
@@ -1,46 +1,28 @@
-type Moments <: ContinuousMultivariateStreamStat
+immutable Moments <: ContinuousMultivariateStreamStat
     m1::Float64
     m2::Float64
     m3::Float64
     m4::Float64
-    n::Int
+    n::Int64
 end
 
-Moments() = Moments(0.0, 0.0, 0.0, 0.0, 0)
+Base.zero(::Type{Moments}) = Moments(0.0, 0.0, 0.0, 0.0, 0)
 
-function update!(stat::Moments, x::Real)
-    stat.n += 1
-
-    n = stat.n
+function Base.(:+)(stat::Moments, x::Real)
+    n = stat.n + 1
 
     δ = x - stat.m1
-    δ_n = δ / stat.n
+    δ_n = δ / n
     δ_n_sq = δ_n * δ_n
     term1 = δ * δ_n * (n - 1)
 
-    stat.m1 += δ_n
-    stat.m4 += term1 * δ_n_sq * (n * n - 3 * n + 3) +
-               6 * δ_n_sq * stat.m2 - 4 * δ_n * stat.m3
-    stat.m3 += term1 * δ_n * (n - 2) - 3 * δ_n * stat.m2
-    stat.m2 += term1
+    m1 = stat.m1 + δ_n
+    m2 = stat.m2 + term1
+    m3 = stat.m3 + term1 * δ_n * (n - 2) - 3 * δ_n * stat.m2
+    m4 = stat.m4 + term1 * δ_n_sq * (n * n - 3 * n + 3) +
+         6 * δ_n_sq * stat.m2 - 4 * δ_n * stat.m3
 
-    return
-end
-
-function Base.mean(stat::Moments)
-    return stat.m1
-end
-
-function Base.var(stat::Moments)
-    return stat.m2 / (stat.n - 1)
-end
-
-function StatsBase.skewness(stat::Moments)
-    return sqrt(stat.n) * stat.m3 / stat.m2^1.5
-end
-
-function StatsBase.kurtosis(stat::Moments)
-    return stat.n * stat.m4 / (stat.m2 * stat.m2) - 3.0
+    return Moments(m1, m2, m3, m4, n)
 end
 
 nobs(stat::Moments) = stat.n
@@ -51,41 +33,30 @@ end
 
 Base.copy(stat::Moments) = Moments(stat.m1, stat.m2, stat.m3, stat.m4, stat.n)
 
-function Base.merge(a::Moments, b::Moments)
-    merged = Moments()
-
-    merged.n = a.n + b.n
+function Base.(:+)(a::Moments, b::Moments)
+    n = a.n + b.n
 
     δ = b.m1 - a.m1
     δ2 = δ * δ
     δ3 = δ * δ2
     δ4 = δ2 * δ2
 
-    merged.m1 = (a.n * a.m1 + b.n * b.m1) / merged.n
+    m1 = (a.n * a.m1 + b.n * b.m1) / n
 
-    merged.m2 = a.m2 + b.m2 + δ2 * a.n * b.n / merged.n
+    m2 = a.m2 + b.m2 + δ2 * a.n * b.n / n
 
-    merged.m3 = a.m3 + b.m3 +
-                  δ3 * a.n * b.n * (a.n - b.n) / (merged.n * merged.n)
-    merged.m3 += 3.0 * δ * (a.n * b.m2 - b.n * a.m2) / merged.n
+    m3 = a.m3 + b.m3 +
+                  δ3 * a.n * b.n * (a.n - b.n) / (n * n)
+    m3 += 3.0 * δ * (a.n * b.m2 - b.n * a.m2) / n
 
-    merged.m4 = a.m4 + b.m4 + δ4 * a.n * b.n *
+    m4 = a.m4 + b.m4 + δ4 * a.n * b.n *
                   (a.n * a.n - a.n * b.n + b.n * b.n) /
-                  (merged.n * merged.n * merged.n)
-    merged.m4 += 6.0 * δ2 * (a.n * a.n * b.m2 + b.n * b.n * a.m2) /
-                   (merged.n * merged.n) +
-                   4.0 * δ * (a.n * b.m3 - b.n * a.m3) / merged.n
+                  (n * n * n)
+    m4 += 6.0 * δ2 * (a.n * a.n * b.m2 + b.n * b.n * a.m2) /
+                   (n * n) +
+                   4.0 * δ * (a.n * b.m3 - b.n * a.m3) / n
 
-    return merged
-end
-
-function Base.empty!(stat::Moments)
-    stat.n = 0
-    stat.m1 = 0.0
-    stat.m2 = 0.0
-    stat.m3 = 0.0
-    stat.m4 = 0.0
-    return
+    return Moments(m1, m2, m3, m4, n)
 end
 
 function Base.show(io::IO, stat::Moments)

--- a/test/moments.jl
+++ b/test/moments.jl
@@ -8,20 +8,25 @@ module TestMoments
     # Moments of uniform draws
     for n in rand(1:1_000_000, 100)
         xs = rand(n)
-        stat = StreamStats.Moments()
-        for x in xs
-            update!(stat, x)
-        end
-        online_ms, online_vs, online_ss, online_ks = state(stat)
-        online_m = mean(xs)
-        online_v = var(xs)
-        online_s = skewness(xs)
-        online_k = kurtosis(xs)
-        online_n = nobs(stat)
         batch_m = mean(xs)
         batch_v = var(xs)
         batch_s = skewness(xs)
         batch_k = kurtosis(xs)
+
+        stats = zeros(StreamStats.Moments, 100)
+        for j = 1:length(stats)
+          for i = j:length(stats):length(xs)
+            stats[j] += xs[i]
+          end
+        end
+
+        stat = sum(stats)
+        online_ms, online_vs, online_ss, online_ks = state(stat)
+        online_m = mean(stat)
+        online_v = var(stat)
+        online_s = skewness(stat)
+        online_k = kurtosis(stat)
+        online_n = nobs(stat)
 
         @test_approx_eq(online_m, batch_m)
         @test_approx_eq(online_ms, batch_m)


### PR DESCRIPTION
Now that Julia 0.4.0 has been released, this seems a good opportunity to introduce some breaking changes to the StreamStats package that will make it suitable for a broader range of use cases.

As a proof of concept, I revised Moments to use an immutable type.

Moments may be used as a scalar (bits) type as before:

``` julia
stat = zero(StreamStats.Moments)
for n = 1:1000
  stat += rand()
end
println(stat)
```

Values are accumulated using the + operator, which allows for an in-place update syntax. 

Moments may be used in an array, and the stats elements may be accumulated using `sum()`:

``` julia
stats = zeros(StreamStats.Moments, 2, 100)
for i = 1:100
  for n = 1:1000
    stats[1, i] += rand()
    stats[2, i] += rand()
  end
end
println(sum(stats))
```
