### PR TITLE
StatsBase updated to no longer give warnings on Julia 0.4

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.3
 StatsBase
 Distributions
+Compat

--- a/src/StreamStats.jl
+++ b/src/StreamStats.jl
@@ -1,6 +1,10 @@
+# VERSION >= v"0.4.0-dev+6521" && __precompile__()
+
 module StreamStats
+    using Compat
     import StatsBase, Distributions
 
+    import StatsBase: nobs
     export update!, state, nobs, replicates
 
     include("streamstat.jl")

--- a/src/StreamStats.jl
+++ b/src/StreamStats.jl
@@ -1,4 +1,4 @@
-# VERSION >= v"0.4.0-dev+6521" && __precompile__()
+VERSION >= v"0.4.0-dev+6521" && __precompile__()
 
 module StreamStats
     using Compat

--- a/src/approx_distinct.jl
+++ b/src/approx_distinct.jl
@@ -15,7 +15,7 @@ end
 
 state(stat::ApproxDistinct) = state(stat.counter)
 
-nobs(stat::ApproxDistinct) = stat.n
+StatsBase.nobs(stat::ApproxDistinct) = stat.n
 
 Base.copy(stat::ApproxDistinct) = ApproxDistinct(copy(stat.counter), 0)
 

--- a/src/approx_l2_logit.jl
+++ b/src/approx_l2_logit.jl
@@ -14,8 +14,8 @@ end
 
 function ApproxL2Logit(p::Integer, λ::Real, α::Real = 0.1)
     return ApproxL2Logit(
-        float64(λ),
-        float64(α),
+        convert(Float64, λ),
+        convert(Float64, α),
         0.0,
         fill(0.0, p),
         0.0,
@@ -50,7 +50,7 @@ end
 
 state(stat::ApproxL2Logit) = vcat(stat.β₀, stat.β)
 
-nobs(stat::ApproxL2Logit) = stat.n
+StatsBase.nobs(stat::ApproxL2Logit) = stat.n
 
 function Base.show(io::IO, stat::ApproxL2Logit)
     p = length(state(stat))

--- a/src/approx_logit.jl
+++ b/src/approx_logit.jl
@@ -12,7 +12,7 @@ type ApproxLogit <: StreamStat
 end
 
 function ApproxLogit(p::Integer, α::Real = 0.1)
-    return ApproxLogit(float64(α), 0.0, fill(0.0, p), 0.0, fill(0.0, p), 0)
+    return ApproxLogit(convert(Float64, α), 0.0, fill(0.0, p), 0.0, fill(0.0, p), 0)
 end
 
 function update!(stat::ApproxLogit, x::Vector{Float64}, y::Real)
@@ -41,7 +41,7 @@ end
 
 state(stat::ApproxLogit) = vcat(stat.β₀, stat.β)
 
-nobs(stat::ApproxLogit) = stat.n
+StatsBase.nobs(stat::ApproxLogit) = stat.n
 
 function Base.show(io::IO, stat::ApproxLogit)
     p = length(state(stat))

--- a/src/approx_ols.jl
+++ b/src/approx_ols.jl
@@ -10,7 +10,7 @@ type ApproxOLS <: StreamStat
 end
 
 function ApproxOLS(p::Integer, α::Real = 0.1)
-    return ApproxOLS(float64(α), 0.0, fill(0.0, p), 0.0, fill(0.0, p), 0)
+    return ApproxOLS(convert(Float64, α), 0.0, fill(0.0, p), 0.0, fill(0.0, p), 0)
 end
 
 function update!(stat::ApproxOLS, x::Vector{Float64}, y::Real)
@@ -39,7 +39,7 @@ end
 
 state(stat::ApproxOLS) = vcat(stat.β₀, stat.β)
 
-nobs(stat::ApproxOLS) = stat.n
+StatsBase.nobs(stat::ApproxOLS) = stat.n
 
 function Base.show(io::IO, stat::ApproxOLS)
     p = length(state(stat))

--- a/src/approx_ridge.jl
+++ b/src/approx_ridge.jl
@@ -12,8 +12,8 @@ end
 
 function ApproxRidge(p::Integer, λ::Real, α::Real = 0.1)
     return ApproxRidge(
-        float64(λ),
-        float64(α),
+        convert(Float64, λ),
+        convert(Float64, α),
         0.0,
         fill(0.0, p),
         0.0,
@@ -48,7 +48,7 @@ end
 
 state(stat::ApproxRidge) = vcat(stat.β₀, stat.β)
 
-nobs(stat::ApproxRidge) = stat.n
+StatsBase.nobs(stat::ApproxRidge) = stat.n
 
 function Base.show(io::IO, stat::ApproxRidge)
     p = length(state(stat))

--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -139,7 +139,7 @@ function ci(stat::Bootstrap, α=0.05, method=:quantile)
     end
 end
 
-nobs(stat::Bootstrap) = stat.n
+StatsBase.nobs(stat::Bootstrap) = stat.n
 
 # Assumes a and b are independent.
 function Base.(:-)(a::Bootstrap, b::Bootstrap)

--- a/src/cov.jl
+++ b/src/cov.jl
@@ -20,7 +20,7 @@ function update!(stat::Covariance, x::Real, y::Real)
     return
 end
 
-nobs(stat::Covariance) = stat.n
+StatsBase.nobs(stat::Covariance) = stat.n
 
 Base.cov(stat::Covariance) = stat.sum_sqs / (stat.n - 1)
 Base.cor(stat::Covariance) = cov(stat) / (std(stat.x) * std(stat.y))

--- a/src/hyper_log_log.jl
+++ b/src/hyper_log_log.jl
@@ -1,28 +1,28 @@
 if VERSION < v"0.4.0-"
     hash32(d::Any) = uint32(hash(d))
 else
-    hash32(d::Any) = hash(d) % Uint32
+    hash32(d::Any) = hash(d) % UInt32
 end
 
-ρ(s::Uint32) = uint32(uint32(leading_zeros(s)) + 0x00000001)
+ρ(s::UInt32) = UInt32(UInt32(leading_zeros(s)) + 0x00000001)
 
-function α(m::Uint32)
+function α(m::UInt32)
     if m == 0x00000010
         return 0.673
     elseif m == 0x00000020
         return 0.697
     elseif m == 0x00000040
         return 0.709
-    else # if m >= uint32(128)
+    else # if m >= UInt32(128)
         return 0.7213 / (1 + 1.079 / m)
     end
 end
 
 type HyperLogLog
-    m::Uint32
-    M::Vector{Uint32}
-    mask::Uint32
-    altmask::Uint32
+    m::UInt32
+    M::Vector{UInt32}
+    mask::UInt32
+    altmask::UInt32
 end
 
 function HyperLogLog(b::Integer)
@@ -32,7 +32,7 @@ function HyperLogLog(b::Integer)
 
     m = 0x00000001 << b
 
-    M = zeros(Uint32, m)
+    M = zeros(UInt32, m)
 
     mask = 0x00000000
     for i in 1:(b - 1)
@@ -47,13 +47,13 @@ function HyperLogLog(b::Integer)
 end
 
 function Base.show(io::IO, counter::HyperLogLog)
-    @printf(io, "A HyperLogLog counter w/ %d registers", int(counter.m))
+    @printf(io, "A HyperLogLog counter w/ %d registers", convert(Int, counter.m))
     return
 end
 
 function update!(counter::HyperLogLog, v::Any)
     x = hash32(v)
-    j = uint32((x & counter.mask) + 0x00000001)
+    j = UInt32((x & counter.mask) + 0x00000001)
     w = x & counter.altmask
     counter.M[j] = max(counter.M[j], ρ(w))
     return
@@ -68,12 +68,12 @@ function state(counter::HyperLogLog)
 
     Z = 1 / S
 
-    E = α(counter.m) * uint(counter.m)^2 * Z
+    E = α(counter.m) * convert(UInt, counter.m)^2 * Z
 
     if E <= 5//2 * counter.m
         V = 0
         for j in 1:counter.m
-            V += int(counter.M[j] == 0x00000000)
+            V += convert(Int, (counter.M[j] == 0x00000000))
         end
         if V != 0
             E_star = counter.m * log(counter.m / V)

--- a/src/max.jl
+++ b/src/max.jl
@@ -15,7 +15,7 @@ Base.maximum(stat::Max) = stat.m
 
 state(stat::Max) = Base.maximum(stat)
 
-nobs(stat::Max) = stat.n
+StatsBase.nobs(stat::Max) = stat.n
 
 Base.copy(stat::Max) = Max(stat.m, stat.n)
 

--- a/src/mean.jl
+++ b/src/mean.jl
@@ -16,7 +16,7 @@ Base.mean(stat::Mean) = stat.m
 
 state(stat::Mean) = Base.mean(stat)
 
-nobs(stat::Mean) = stat.n
+StatsBase.nobs(stat::Mean) = stat.n
 
 Base.copy(stat::Mean) = Mean(stat.m, stat.n)
 

--- a/src/min.jl
+++ b/src/min.jl
@@ -15,7 +15,7 @@ Base.minimum(stat::Min) = stat.m
 
 state(stat::Min) = Base.minimum(stat)
 
-nobs(stat::Min) = stat.n
+StatsBase.nobs(stat::Min) = stat.n
 
 Base.copy(stat::Min) = Min(stat.m, stat.n)
 

--- a/src/moments.jl
+++ b/src/moments.jl
@@ -43,7 +43,7 @@ function StatsBase.kurtosis(stat::Moments)
     return stat.n * stat.m4 / (stat.m2 * stat.m2) - 3.0
 end
 
-nobs(stat::Moments) = stat.n
+StatsBase.nobs(stat::Moments) = stat.n
 
 function state(stat::Moments)
     return (mean(stat), var(stat), StatsBase.skewness(stat), StatsBase.kurtosis(stat))

--- a/src/sample.jl
+++ b/src/sample.jl
@@ -35,7 +35,7 @@ end
 
 StatsBase.sample{T}(stat::Sample{T}) = state(stat)
 
-nobs(stat::Sample) = stat.n
+StatsBase.nobs(stat::Sample) = stat.n
 
 Base.copy(stat::Sample) = Sample(stat.sample, stat.n)
 

--- a/src/var.jl
+++ b/src/var.jl
@@ -32,7 +32,7 @@ Base.mean(stat::Variance) = stat.m
 
 state(stat::Variance) = var(stat)
 
-nobs(stat::Variance) = stat.n
+StatsBase.nobs(stat::Variance) = stat.n
 
 function Base.copy(stat::Variance)
     return Variance(stat.m, stat.sum_sqs, stat.v_hat, stat.n)


### PR DESCRIPTION
I changed the types used in StatsBase to reflect Julia 0.4, and include Compat so things should still run with Julia 0.3.
obs is now in StatsBase, so I pull that in as well.
